### PR TITLE
Allow passing dockerfile build arguments from within build.yml

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -231,6 +231,9 @@ func (b *Builder) BuildStep(step *Step, step_number int) error {
 	for _, s := range b.Conf.BuildArgs {
 		buildArgs = append(buildArgs, docker.BuildArg{Name: s.Key, Value: s.Value})
 	}
+	for k, v := range step.Args {
+		buildArgs = append(buildArgs, docker.BuildArg{Name: k, Value: v})
+	}
 	// call Docker to build the Dockerfile (from the parsed file)
 
 	b.Conf.Logger.Infof("Step %d - Building the %s image from %s", step_number+1, b.uniqueStepName(step), b.uniqueDockerfile(step))

--- a/build/manifest.go
+++ b/build/manifest.go
@@ -37,12 +37,15 @@ type Secret struct {
 	Value string
 }
 
+type BuildArgs map[string]string
+
 // Step Holds a single step in the build process
 // Public structs. They are used to store the build for the builders
 type Step struct {
 	Name       string
 	Label      string
 	Dockerfile string
+	Args       BuildArgs
 	Artifacts  []Artifact
 	Manifest   *Manifest
 	Cleanup    *Cleanup
@@ -71,10 +74,13 @@ type secret struct {
 	Value string `yaml:"value"`
 }
 
+type buildArgs map[string]string
+
 // Private structs. They are used to load from yaml
 type step struct {
 	Name       string            `yaml:"name"`
 	Dockerfile string            `yaml:"dockerfile"`
+	Args       buildArgs         `yaml:"args"`
 	Artifacts  []string          `yaml:"artifacts"`
 	Cleanup    *cleanup          `yaml:"cleanup"`
 	DependsOn  []string          `yaml:"depends_on"`
@@ -142,6 +148,7 @@ func (n *namespace) convertToBuild(version string) (*Manifest, error) {
 		convertedStep.Dockerfile = s.Dockerfile
 		convertedStep.Name = s.Name
 		convertedStep.Label = name
+		convertedStep.Args = BuildArgs(s.Args)
 		convertedStep.Artifacts = []Artifact{}
 		convertedStep.Command = s.Command
 		convertedStep.AfterBuildCommand = s.AfterBuildCommand

--- a/examples/buildarguments/README.md
+++ b/examples/buildarguments/README.md
@@ -1,3 +1,5 @@
 Run this example using Habitus: `habitus -f examples/buildarguments/build.yml -d examples/buildarguments --build BUILD_ARGUMENT=awesome --env NAME=wow`
 
+Or with the alternative build.yaml contains the build argument: `habitus -f examples/buildarguments/build-contained.yml -d examples/buildarguments --env NAME=wow`
+
 It will build the steps and create a dynamic step name called *step_wow* and set the environment variable in the Dockerfile called *AWESOME_ENVIRONMENT* to the *BUILD_ARGUMENT* which is awesome ;-)

--- a/examples/buildarguments/build-contained.yml
+++ b/examples/buildarguments/build-contained.yml
@@ -1,0 +1,10 @@
+# a build.yml to build Habitus cross-platform using Habitus
+build:
+  version: 2016-03-14
+  steps:
+    step1:
+      name: _env(NAME)
+      dockerfile: Dockerfile
+      args:
+        BUILD_ARGUMENT: awesome
+      command: env


### PR DESCRIPTION
Verified manually by running habitus with the existing and the new example config respectively:

```
$ habitus -f examples/buildarguments/build.yml -d examples/buildarguments --build BUILD_ARGUMENT=awesome --env NAME=wow`
*snip*
$ docker inspect wow:latest | grep awesome
                "AWESOME_ENVIRONMENT=awesome"
                "ENV AWESOME_ENVIRONMENT=awesome"
                "AWESOME_ENVIRONMENT=awesome"
```

NEW: Alternative with build args from the yml:

```
$ habitus -f examples/buildarguments/build-contained.yml -d examples/buildarguments --env NAME=wow`
*snip*
$ docker inspect wow:latest | grep awesome
                "AWESOME_ENVIRONMENT=awesome"
                "ENV AWESOME_ENVIRONMENT=awesome"
                "AWESOME_ENVIRONMENT=awesome"
```

Closes #74