### PR TITLE
Tighter integration with Docker multi-stage builds

### DIFF
--- a/build/dockerfile.go
+++ b/build/dockerfile.go
@@ -1,0 +1,37 @@
+package build
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func readDockerfileToTarget(dockerfile string, target string) (string, error) {
+	targetPattern := regexp.MustCompile(fmt.Sprintf(`\s+[aA][sS]\s+%s\s*$`, target))
+	nextPattern := regexp.MustCompile(`\s+[aA][sS]\s+.+\s*$`)
+
+	scanner := bufio.NewScanner(strings.NewReader(dockerfile))
+	buf := bytes.NewBuffer(make([]byte, 0, len(dockerfile)))
+
+	targetFound := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Read dockerfile until the end of the target stage
+		if targetFound && nextPattern.MatchString(line) {
+			break
+		} else if targetPattern.MatchString(line) {
+			targetFound = true
+		}
+		buf.WriteString(line)
+		buf.WriteString("\n")
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("[bug] failed to process generated dockerfile: %v", err)
+	}
+	if !targetFound {
+		return "", fmt.Errorf(`build target "%s" does not exist in Dockerfile - double-check that the target is not misspelled`, target)
+	}
+	return buf.String(), nil
+}

--- a/build/manifest.go
+++ b/build/manifest.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	validTypes = []string{"file","env"}
+	validTypes = []string{"file", "env"}
 )
 
 // Artifact holds a parsed source for a build artifact
@@ -42,18 +42,19 @@ type BuildArgs map[string]string
 // Step Holds a single step in the build process
 // Public structs. They are used to store the build for the builders
 type Step struct {
-	Name       string
-	Label      string
-	Dockerfile string
-	Args       BuildArgs
-	Artifacts  []Artifact
-	Manifest   *Manifest
-	Cleanup    *Cleanup
-	DependsOn  []*Step
-	Command    string
+	Name              string
+	Label             string
+	Dockerfile        string
+	Args              BuildArgs
+	Artifacts         []Artifact
+	Manifest          *Manifest
+	Target            string
+	Cleanup           *Cleanup
+	DependsOn         []*Step
+	Command           string
 	AfterBuildCommand string
-	NoCache		bool
-	Secrets    []Secret
+	NoCache           bool
+	Secrets           []Secret
 }
 
 // Manifest Holds the whole build process
@@ -78,16 +79,17 @@ type buildArgs map[string]string
 
 // Private structs. They are used to load from yaml
 type step struct {
-	Name       string            `yaml:"name"`
-	Dockerfile string            `yaml:"dockerfile"`
-	Args       buildArgs         `yaml:"args"`
-	Artifacts  []string          `yaml:"artifacts"`
-	Cleanup    *cleanup          `yaml:"cleanup"`
-	DependsOn  []string          `yaml:"depends_on"`
-	Command    string            `yaml:"command"`
-	AfterBuildCommand string 	 `yaml:"after_build_command"`
-	NoCache 	bool			 `yaml:"no_cache"`
-	Secrets    map[string]secret `yaml:"secrets"`
+	Name              string            `yaml:"name"`
+	Dockerfile        string            `yaml:"dockerfile"`
+	Args              buildArgs         `yaml:"args"`
+	Artifacts         []string          `yaml:"artifacts"`
+	Target            string            `yaml:"target"`
+	Cleanup           *cleanup          `yaml:"cleanup"`
+	DependsOn         []string          `yaml:"depends_on"`
+	Command           string            `yaml:"command"`
+	AfterBuildCommand string            `yaml:"after_build_command"`
+	NoCache           bool              `yaml:"no_cache"`
+	Secrets           map[string]secret `yaml:"secrets"`
 }
 
 // This is loaded from the build.yml file
@@ -137,7 +139,6 @@ func (n *namespace) convertToBuild(version string) (*Manifest, error) {
 	manifest.SecretProviders["file"] = &secrets.FileProvider{}
 	manifest.SecretProviders["env"] = &secrets.EnvProvider{}
 
-
 	manifest.IsPrivileged = false
 	manifest.Steps = []Step{}
 
@@ -150,6 +151,7 @@ func (n *namespace) convertToBuild(version string) (*Manifest, error) {
 		convertedStep.Label = name
 		convertedStep.Args = BuildArgs(s.Args)
 		convertedStep.Artifacts = []Artifact{}
+		convertedStep.Target = s.Target
 		convertedStep.Command = s.Command
 		convertedStep.AfterBuildCommand = s.AfterBuildCommand
 		convertedStep.NoCache = s.NoCache

--- a/examples/multistage/Dockerfile
+++ b/examples/multistage/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.5 As base
+RUN echo 'the base'
+
+FROM base aS  compile
+RUN echo 'compiling'
+
+FROM base  AS runtime
+RUN echo 'runtime'

--- a/examples/multistage/build.yml
+++ b/examples/multistage/build.yml
@@ -1,0 +1,19 @@
+build:
+    version: 2016-03-14
+    steps:
+      base:
+        name: base
+        dockerfile: Dockerfile
+        target: base
+      compilation:
+        name: compilation
+        dockerfile: Dockerfile
+        target: compile
+        depends_on:
+          - base
+      runtime:
+        name: runtime
+        dockerfile: Dockerfile
+        target: runtime
+        depends_on:
+          - compilation


### PR DESCRIPTION
Point multiple steps to the same Dockerfile, but with different stage by specifying `target` in `build.yaml`, so that:

- You can leverage Docker's native multi-stage build feature for theoretically faster assets propagation due to no `docker cp` between the nodes habitus and docker-daemon are running respectively.
- An easiger migration path for usual Docker users used to multi-stage builds. They benefit from habitus' advanced features like build secrets without splitting Dockerfile

The implementation of splitting Dockerfile for a targeted build is inspired by the implementation of [Docker's](https://github.com/moby/moby/blob/3a633a712c8bbb863fe7e57ec132dd87a9c4eff7/builder/dockerfile/builder.go#L232-L239).
But this one is slightly more naive than the original, due to `fsouza/go-dockerclient` doesn't support targeted build or injecting Dockerfile content rather than the filepath to it.
This implementation, although it is native, seemed better than greatly hacking fsouzo/go-dockerclient or incorporating the official docker-client just for this use-case.

This is verified manually by running habitus with the new example at `exampls/multistage/build.yml`:

```console
2018/03/14 18:50:47 ▶ Using '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage/build.yml' as build file
2018/03/14 18:50:47 ▶ Collecting artifact information
2018/03/14 18:50:47 ▶ Building 3 steps
2018/03/14 18:50:47 ▶ Step 1 - base, image-name = 'base'
2018/03/14 18:50:47 ▶ Step 2 - compilation, image-name = 'compilation'
2018/03/14 18:50:47 ▶ Step 3 - runtime, image-name = 'runtime'
2018/03/14 18:50:47 ▶ Step 1 - Build for base
2018/03/14 18:50:47 ▶ Step 1 - Building base from context '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage'
2018/03/14 18:50:47 ▶ Step 1 - Parsing and converting 'Dockerfile'
2018/03/14 18:50:47 ▶ Step 1 - Writing the new Dockerfile into '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage/Dockerfile.generated'
2018/03/14 18:50:47 ▶ Step 1 - Building the base image from /Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage/Dockerfile.generated
Step 1/2 : FROM alpine:3.5 As base
 ---> 6c6084ed97e5
Step 2/2 : RUN echo 'the base'
 ---> Using cache
 ---> 960b4976bfa7
Successfully built 960b4976bfa7
Successfully tagged base:latest
2018/03/14 18:50:47 ▶ Step 2 - Build for compilation
2018/03/14 18:50:47 ▶ Step 2 - Building compilation from context '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage'
2018/03/14 18:50:47 ▶ Step 2 - Parsing and converting 'Dockerfile'
2018/03/14 18:50:47 ▶ Step 2 - Writing the new Dockerfile into '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage/Dockerfile.generated'
2018/03/14 18:50:47 ▶ Step 2 - Building the compilation image from /Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage/Dockerfile.generated
Step 1/4 : FROM alpine:3.5 As base
 ---> 6c6084ed97e5
Step 2/4 : RUN echo 'the base'
 ---> Using cache
 ---> 960b4976bfa7
Step 3/4 : FROM base aS compile
 ---> 960b4976bfa7
Step 4/4 : RUN echo 'compiling'
 ---> Running in a6a55d38773c
compiling
 ---> 598ac9b1ef0b
Removing intermediate container a6a55d38773c
Successfully built 598ac9b1ef0b
Successfully tagged compilation:latest
2018/03/14 18:50:47 ▶ Step 3 - Build for runtime
2018/03/14 18:50:47 ▶ Step 3 - Building runtime from context '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage'
2018/03/14 18:50:47 ▶ Step 3 - Parsing and converting 'Dockerfile'
2018/03/14 18:50:47 ▶ Step 3 - Writing the new Dockerfile into '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage/Dockerfile.generated'
2018/03/14 18:50:47 ▶ Step 3 - Building the runtime image from /Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/multistage/Dockerfile.generated
Step 1/6 : FROM alpine:3.5 As base
 ---> 6c6084ed97e5
Step 2/6 : RUN echo 'the base'
 ---> Using cache
 ---> 960b4976bfa7
Step 3/6 : FROM base aS compile
 ---> 960b4976bfa7
Step 4/6 : RUN echo 'compiling'
 ---> Using cache
 ---> 598ac9b1ef0b
Step 5/6 : FROM base AS runtime
 ---> 960b4976bfa7
Step 6/6 : RUN echo 'runtime'
 ---> Using cache
 ---> 7c6308850176
Successfully built 7c6308850176
Successfully tagged runtime:latest
2018/03/14 18:50:48 ▶ Step 1 - Removing unwanted image base
2018/03/14 18:50:48 ▶ Step 2 - Removing unwanted image compilation
```

Resolves #89