### PR TITLE
Allow setting networking mode or docker network during build

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -251,6 +251,7 @@ func (b *Builder) BuildStep(step *Step, step_number int) error {
 	b.Conf.Logger.Infof("Step %d - Building the %s image from %s", step_number+1, b.uniqueStepName(step), b.uniqueDockerfile(step))
 	opts := docker.BuildImageOptions{
 		Name:                b.uniqueStepName(step),
+		NetworkMode:         b.Conf.Network,
 		Dockerfile:          b.uniqueDockerfileName(step),
 		NoCache:             b.Conf.NoCache || step.NoCache,
 		SuppressOutput:      b.Conf.SuppressOutput,

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -16,36 +16,37 @@ type TupleArray []TupleItem
 
 // Config stores application configurations
 type Config struct {
-	Buildfile               string
-	Workdir                 string
-	NoCache                 bool
-	SuppressOutput          bool
-	RmTmpContainers         bool
-	ForceRmTmpContainer     bool
-	UniqueID                string
-	Logger                  logging.Logger
-	DockerHost              string
-	DockerCert              string
-	EnvVars                 TupleArray
-	BuildArgs               TupleArray
-	KeepSteps               bool
-	KeepArtifacts           bool
-	NoSquash                bool
-	NoPruneRmImages         bool
-	UseTLS                  bool
-	UseStatForPermissions	bool
-	FroceRmImages           bool
-	ApiPort                 int
-	ApiBinding              string
-	SecretService           bool
-	AllowAfterBuildCommands bool
-	SecretProviders         string
-	DockerMemory            string
-	DockerCPUSetCPUs        string
-	DockerCPUShares         int
-	UseAuthenticatedSecretServer bool
+	Buildfile                         string
+	Workdir                           string
+	NoCache                           bool
+	SuppressOutput                    bool
+	RmTmpContainers                   bool
+	ForceRmTmpContainer               bool
+	UniqueID                          string
+	Logger                            logging.Logger
+	DockerHost                        string
+	DockerCert                        string
+	EnvVars                           TupleArray
+	BuildArgs                         TupleArray
+	KeepSteps                         bool
+	KeepArtifacts                     bool
+	Network                           string
+	NoSquash                          bool
+	NoPruneRmImages                   bool
+	UseTLS                            bool
+	UseStatForPermissions             bool
+	FroceRmImages                     bool
+	ApiPort                           int
+	ApiBinding                        string
+	SecretService                     bool
+	AllowAfterBuildCommands           bool
+	SecretProviders                   string
+	DockerMemory                      string
+	DockerCPUSetCPUs                  string
+	DockerCPUShares                   int
+	UseAuthenticatedSecretServer      bool
 	AuthenticatedSecretServerPassword string
-	AuthenticatedSecretServerUser string
+	AuthenticatedSecretServerUser     string
 }
 
 func (i *TupleArray) String() string {

--- a/examples/network/Dockerfile
+++ b/examples/network/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu
+RUN apt-get update && apt-get install -y wget
+
+ARG host
+ARG port
+ENV ASSET /asset
+RUN wget -q -O $ASSET http://$host:$port/
+RUN cat $ASSET

--- a/examples/network/README.md
+++ b/examples/network/README.md
@@ -1,0 +1,9 @@
+Run this example using network
+
+```console
+docker run --name mynginx -d --network mynetwork nginx:latest
+
+host=$(docker inspect mynginx | jq -r '.[0].NetworkSettings.Networks.mynetwork.IPAddress')
+
+habitus --build host=$host --build port=80 --network mynetwork
+```

--- a/examples/network/build.yml
+++ b/examples/network/build.yml
@@ -1,0 +1,10 @@
+build:
+  version: 2016-03-14
+  steps:
+    builder:
+      name: builder
+      dockerfile: Dockerfile
+      secrets:
+        id_rsa:
+          type: file
+          value: _env(HOME)/.ssh/id_rsa


### PR DESCRIPTION
This feature allows you to e.g. access another docker containers from within a build for fetching build assets.

See [this comment](https://github.com/cloud66/habitus/issues/80#issuecomment-373339156) why this is implemented as a flag rather than a key in build.yml.

Also see [the description about `--network` in the docker engine doc](https://docs.docker.com/engine/reference/commandline/build/) for more information, especially about why it is "networking mode" OR "network".

Resolves #80

This is verified manually by running habitus with the new example at exampls/network/build.yml:

```
$ ~/bin/habitus --build host=$host --build port=80 --network mynetwork
2018/03/15 20:39:27 ▶ Using '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/network/build.yml' as build file
2018/03/15 20:39:27 ▶ Collecting artifact information
2018/03/15 20:39:27 ▶ Building 1 steps
2018/03/15 20:39:27 ▶ Step 1 - builder, image-name = 'builder'
2018/03/15 20:39:27 ▶ Step 1 - Build for builder
2018/03/15 20:39:27 ▶ Step 1 - Building builder from context '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/network'
2018/03/15 20:39:27 ▶ Step 1 - Parsing and converting 'Dockerfile'
2018/03/15 20:39:27 ▶ Step 1 - Writing the new Dockerfile into '/Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/network/Dockerfile.generated'
2018/03/15 20:39:27 ▶ Step 1 - Building the builder image from /Users/kuoka-yusuke/go/src/github.com/cloud66/habitus/examples/network/Dockerfile.generated
Step 1/7 : FROM ubuntu
 ---> f975c5035748
Step 2/7 : RUN apt-get update && apt-get install -y wget
 ---> Using cache
 ---> 07821c8ff8f6
Step 3/7 : ARG host
 ---> Using cache
 ---> 3fab8034e46a
Step 4/7 : ARG port
 ---> Using cache
 ---> 004ee59f9a02
Step 5/7 : ENV ASSET /asset
 ---> Using cache
 ---> 20e3d5b78f2d
Step 6/7 : RUN wget -q -O $ASSET http://$host:$port/
 ---> Running in ad7137afc4cb
 ---> f94330eacbcd
Removing intermediate container ad7137afc4cb
Step 7/7 : RUN cat $ASSET
 ---> Running in c7cd838be46d
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
 ---> ecd4a27d7b4d
Removing intermediate container c7cd838be46d
Successfully built ecd4a27d7b4d
Successfully tagged builder:latest
```