### PR TITLE
WIP: Containerized secret server

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,12 @@
+FROM alpine:3.7
+MAINTAINER Daniël van Gils
+
+RUN apk add --update --no-cache ca-certificates
+
+COPY ./compiled/habitus_linux_amd64 /usr/local/bin/habitus
+
+RUN mkdir /var/habitus
+
+WORKDIR /var/habitus
+
+CMD [ "habitus", "server" ]

--- a/api/server.go
+++ b/api/server.go
@@ -6,34 +6,36 @@ import (
 	"os"
 
 	"github.com/ant0ine/go-json-rest/rest"
-	"github.com/cloud66/habitus/build"
+	"github.com/cloud66/habitus/configuration"
+	"github.com/cloud66/habitus/secrets"
 )
 
 var (
-	VERSION         string = "dev"
+	VERSION string = "dev"
 )
 
-
 type Server struct {
-	Builder *build.Builder
+	Conf            *configuration.Server
+	secretProviders map[string]secrets.SecretProvider
 }
 
 func (s *Server) StartServer(version string) error {
 	VERSION = version
 	secret_api := rest.NewApi()
 
-	if s.Builder.Conf.UseAuthenticatedSecretServer {
+	s.secretProviders = secrets.GetProviders()
+
+	if s.Conf.UseAuthenticatedSecretServer {
 		secret_api.Use(&rest.AuthBasicMiddleware{
 			Realm: "Habitus secret service",
 			Authenticator: func(userId string, password string) bool {
-				if userId == s.Builder.Conf.AuthenticatedSecretServerUser && password == s.Builder.Conf.AuthenticatedSecretServerPassword {
+				if userId == s.Conf.AuthenticatedSecretServerUser && password == s.Conf.AuthenticatedSecretServerPassword {
 					return true
 				}
 				return false
 			},
 		})
 	}
-
 
 	router, err := rest.MakeRouter(
 		// system
@@ -51,11 +53,11 @@ func (s *Server) StartServer(version string) error {
 	secret_api.SetApp(router)
 
 	go func() {
-		s.Builder.Conf.Logger.Infof("Starting API on %d", s.Builder.Conf.ApiPort)
+		s.Conf.Logger.Infof("Starting API on %d", s.Conf.ApiPort)
 
 		// 192.168.99.1
-		if err := http.ListenAndServe(fmt.Sprintf("%s:%d", s.Builder.Conf.ApiBinding, s.Builder.Conf.ApiPort), secret_api.MakeHandler()); err != nil {
-			s.Builder.Conf.Logger.Errorf("Failed to start API %s", err.Error())
+		if err := http.ListenAndServe(fmt.Sprintf("%s:%d", s.Conf.ApiBinding, s.Conf.ApiPort), secret_api.MakeHandler()); err != nil {
+			s.Conf.Logger.Errorf("Failed to start API %s", err.Error())
 			os.Exit(2)
 		}
 
@@ -74,7 +76,7 @@ func (a *Server) version(w rest.ResponseWriter, r *rest.Request) {
 
 func (a *Server) serveSecret(w rest.ResponseWriter, r *rest.Request) {
 	// get the provider
-	provider := a.Builder.Build.SecretProviders[r.PathParam("type")]
+	provider := a.secretProviders[r.PathParam("type")]
 	result, err := provider.GetSecret(r.PathParam("name"))
 	if err != nil {
 		rest.Error(w, err.Error(), http.StatusBadRequest)

--- a/build.yml
+++ b/build.yml
@@ -14,3 +14,8 @@ build:
       artifacts:
         # copy all the artifacts from the compiled folder
         - /usr/local/go/src/github.com/cloud66/habitus/compiled:.
+    server:
+      name: server
+      depends_on:
+        - crosscompile
+      dockerfile: Dockerfile.server

--- a/build/builder.go
+++ b/build/builder.go
@@ -251,6 +251,7 @@ func (b *Builder) BuildStep(step *Step, step_number int) error {
 	b.Conf.Logger.Infof("Step %d - Building the %s image from %s", step_number+1, b.uniqueStepName(step), b.uniqueDockerfile(step))
 	opts := docker.BuildImageOptions{
 		Name:                b.uniqueStepName(step),
+		NetworkMode:         b.Conf.Network,
 		Dockerfile:          b.uniqueDockerfileName(step),
 		NoCache:             b.Conf.NoCache || step.NoCache,
 		SuppressOutput:      b.Conf.SuppressOutput,

--- a/build/manifest.go
+++ b/build/manifest.go
@@ -134,10 +134,8 @@ func LoadBuildFromFile(config *configuration.Config) (*Manifest, error) {
 
 func (n *namespace) convertToBuild(version string) (*Manifest, error) {
 	manifest := Manifest{
-		SecretProviders: make(map[string]secrets.SecretProvider),
+		SecretProviders: secrets.GetProviders(),
 	}
-	manifest.SecretProviders["file"] = &secrets.FileProvider{}
-	manifest.SecretProviders["env"] = &secrets.EnvProvider{}
 
 	manifest.IsPrivileged = false
 	manifest.Steps = []Step{}

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -16,36 +16,37 @@ type TupleArray []TupleItem
 
 // Config stores application configurations
 type Config struct {
-	Buildfile               string
-	Workdir                 string
-	NoCache                 bool
-	SuppressOutput          bool
-	RmTmpContainers         bool
-	ForceRmTmpContainer     bool
-	UniqueID                string
-	Logger                  logging.Logger
-	DockerHost              string
-	DockerCert              string
-	EnvVars                 TupleArray
-	BuildArgs               TupleArray
-	KeepSteps               bool
-	KeepArtifacts           bool
-	NoSquash                bool
-	NoPruneRmImages         bool
-	UseTLS                  bool
-	UseStatForPermissions	bool
-	FroceRmImages           bool
-	ApiPort                 int
-	ApiBinding              string
-	SecretService           bool
-	AllowAfterBuildCommands bool
-	SecretProviders         string
-	DockerMemory            string
-	DockerCPUSetCPUs        string
-	DockerCPUShares         int
-	UseAuthenticatedSecretServer bool
+	Buildfile                         string
+	Workdir                           string
+	NoCache                           bool
+	SuppressOutput                    bool
+	RmTmpContainers                   bool
+	ForceRmTmpContainer               bool
+	UniqueID                          string
+	Logger                            logging.Logger
+	DockerHost                        string
+	DockerCert                        string
+	EnvVars                           TupleArray
+	BuildArgs                         TupleArray
+	KeepSteps                         bool
+	KeepArtifacts                     bool
+	Network                           string
+	NoSquash                          bool
+	NoPruneRmImages                   bool
+	UseTLS                            bool
+	UseStatForPermissions             bool
+	FroceRmImages                     bool
+	ApiPort                           int
+	ApiBinding                        string
+	SecretService                     bool
+	AllowAfterBuildCommands           bool
+	SecretProviders                   string
+	DockerMemory                      string
+	DockerCPUSetCPUs                  string
+	DockerCPUShares                   int
+	UseAuthenticatedSecretServer      bool
 	AuthenticatedSecretServerPassword string
-	AuthenticatedSecretServerUser string
+	AuthenticatedSecretServerUser     string
 }
 
 func (i *TupleArray) String() string {

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -14,39 +14,44 @@ type TupleItem struct {
 
 type TupleArray []TupleItem
 
+type Server struct {
+	ApiBinding                        string
+	ApiPort                           int
+	AuthenticatedSecretServerUser     string
+	AuthenticatedSecretServerPassword string
+	Logger                            logging.Logger
+	UseAuthenticatedSecretServer      bool
+}
+
 // Config stores application configurations
 type Config struct {
-	Buildfile                         string
-	Workdir                           string
-	NoCache                           bool
-	SuppressOutput                    bool
-	RmTmpContainers                   bool
-	ForceRmTmpContainer               bool
-	UniqueID                          string
-	Logger                            logging.Logger
-	DockerHost                        string
-	DockerCert                        string
-	EnvVars                           TupleArray
-	BuildArgs                         TupleArray
-	KeepSteps                         bool
-	KeepArtifacts                     bool
-	Network                           string
-	NoSquash                          bool
-	NoPruneRmImages                   bool
-	UseTLS                            bool
-	UseStatForPermissions             bool
-	FroceRmImages                     bool
-	ApiPort                           int
-	ApiBinding                        string
-	SecretService                     bool
-	AllowAfterBuildCommands           bool
-	SecretProviders                   string
-	DockerMemory                      string
-	DockerCPUSetCPUs                  string
-	DockerCPUShares                   int
-	UseAuthenticatedSecretServer      bool
-	AuthenticatedSecretServerPassword string
-	AuthenticatedSecretServerUser     string
+	Server
+	Buildfile               string
+	Workdir                 string
+	NoCache                 bool
+	SuppressOutput          bool
+	RmTmpContainers         bool
+	ForceRmTmpContainer     bool
+	UniqueID                string
+	Logger                  logging.Logger
+	DockerHost              string
+	DockerCert              string
+	EnvVars                 TupleArray
+	BuildArgs               TupleArray
+	KeepSteps               bool
+	KeepArtifacts           bool
+	Network                 string
+	NoSquash                bool
+	NoPruneRmImages         bool
+	UseTLS                  bool
+	UseStatForPermissions   bool
+	FroceRmImages           bool
+	SecretService           bool
+	AllowAfterBuildCommands bool
+	SecretProviders         string
+	DockerMemory            string
+	DockerCPUSetCPUs        string
+	DockerCPUShares         int
 }
 
 func (i *TupleArray) String() string {

--- a/examples/network/Dockerfile
+++ b/examples/network/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu
+RUN apt-get update && apt-get install -y wget
+
+ARG host
+ARG port
+ENV ASSET /asset
+RUN wget -q -O $ASSET http://$host:$port/
+RUN cat $ASSET

--- a/examples/network/README.md
+++ b/examples/network/README.md
@@ -1,0 +1,9 @@
+Run this example using network
+
+```console
+docker run --name mynginx -d --network mynetwork nginx:latest
+
+host=$(docker inspect mynginx | jq -r '.[0].NetworkSettings.Networks.mynetwork.IPAddress')
+
+habitus --build host=$host --build port=80 --network mynetwork
+```

--- a/examples/network/build.yml
+++ b/examples/network/build.yml
@@ -1,0 +1,10 @@
+build:
+  version: 2016-03-14
+  steps:
+    builder:
+      name: builder
+      dockerfile: Dockerfile
+      secrets:
+        id_rsa:
+          type: file
+          value: _env(HOME)/.ssh/id_rsa

--- a/main.go
+++ b/main.go
@@ -145,8 +145,9 @@ func main() {
 
 	if config.SecretService {
 		// start the API
-		secret_service := &api.Server{Builder: b}
-		err = secret_service.StartServer(VERSION)
+		// TODO Wrap this into a docker-container in case of -containerize-server
+		server := &api.Server{Conf: &b.Conf.Server}
+		err = server.StartServer(VERSION)
 		if err != nil {
 			log.Fatalf("Cannot start API server due to %s", err.Error())
 			os.Exit(2)

--- a/secrets/get_providers.go
+++ b/secrets/get_providers.go
@@ -1,0 +1,8 @@
+package secrets
+
+func GetProviders() map[string]SecretProvider {
+	return map[string]SecretProvider{
+		"file": &FileProvider{},
+		"env":  &EnvProvider{},
+	}
+}


### PR DESCRIPTION
Depends on #94
Resolves #95

If anyone is interested in reviewing this, please see commits only added on top of the dependency.

## Goals

In nutshell, I'll address the following items in this PR:

- [ ] A new command `habitus server` to be run inside a container to serve the secret API in a specific docker network
 - [ ] An alternative `api.Server` impl which delegates actual execution of the secret API server to `docker run`
- [ ] A flag `-containerize-api-server` which enables the containerized secret server(and on the other hand disables the traditional, embedded secret server)
- [ ] A docker image for habitus.

## Synopsis

Either of the followings:

- `habitus --containerize-api-server`
- `docker run --network mynetwork cloud66/habitus:v1.x.x habitus server -foo -bar` to run the secret server in the docker network named `mynetwork` and then `habitus --network mynetwork` to run a habitus build inside the network.

## Random notes on design and implementation

- [ ] A flag like `-server-timeout=600s` to instruct the secret server container to suicide after 10min would be helpful to not leave the secret server running, which introduces an extra chance of secret breach.