### PR TITLE
Adds a more useful error message.

### DIFF
--- a/build/manifest.go
+++ b/build/manifest.go
@@ -128,7 +128,7 @@ func LoadBuildFromFile(config *configuration.Config) (*Manifest, error) {
 	// check the version. for now we are going to support only one version
 	// in future, version will select the parser
 	if (n.BuildConfig.Version != "2016-02-13") && (n.BuildConfig.Version != "2016-03-14") {
-		return nil, errors.New("Invalid build schema version")
+		return nil, errors.New("Invalid build schema version. \n The property build.version allows only the following two valid values: 2016-02-13 or 2016-03-14.")
 	}
 
 	return n.convertToBuild(n.BuildConfig.Version)


### PR DESCRIPTION
Extending the Error Message when we set a version schema which isn't allowed. As an new user which tries your build management tool for the first time, I run into this as first issue, and the documentation didn't tell me anything about this configuration property and what the version schema has to do with my build. 

This quick-win, of self documentation an throwing an Error should be helpful for the next new user of habitus.
Sorry I have no experience with golang, I just hope that "\n works."